### PR TITLE
Rename `appdata.xml` to `com.github.skylot.jadx.metainfo.xml`

### DIFF
--- a/com.github.skylot.jadx.json
+++ b/com.github.skylot.jadx.json
@@ -50,7 +50,7 @@
                 },
                 {
                     "type": "file",
-                    "path": "appdata.xml"
+                    "path": "com.github.skylot.jadx.metainfo.xml"
                 }
             ],
             "buildsystem": "simple",
@@ -63,7 +63,7 @@
                 "install -Dm 644 -t $FLATPAK_DEST/share/licenses/jadx LICENSE",
                 "install -D jadx-logo.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg",
                 "install -Dm 644 jadx.desktop $FLATPAK_DEST/share/applications/${FLATPAK_ID}.desktop",
-                "install -Dm 644 appdata.xml $FLATPAK_DEST/share/appdata/${FLATPAK_ID}.appdata.xml"
+                "install -Dm 644 ${FLATPAK_ID}.metainfo.xml -t ${FLATPAK_DEST}/share/metainfo"
             ]
         }
     ]

--- a/com.github.skylot.jadx.metainfo.xml
+++ b/com.github.skylot.jadx.metainfo.xml
@@ -23,6 +23,7 @@
     </description>
     <screenshots>
         <screenshot type="default">
+            <caption>Main window</caption>
             <image>https://user-images.githubusercontent.com/118523/142730720-839f017e-38db-423e-b53f-39f5f0a0316f.png</image>
         </screenshot>
     </screenshots>


### PR DESCRIPTION
This allows the [Flatpak External Data Checker](https://github.com/flathub-infra/flatpak-external-data-checker) to modify the AppData file automatically whenever a new version of JADX is released, thus not requiring manual work to update the file in the pull request.

This also adds a missing `<caption>` tag for the screenshot in the AppData file, fixing [this warning](https://docs.flathub.org/docs/for-app-authors/linter#appstream-screenshot-missing-caption) from [`flatpak-builder-lint`](https://github.com/flathub-infra/flatpak-builder-lint):

